### PR TITLE
Update SPAR 16 config.cpp for CBA/ASDG rails compatibility

### DIFF
--- a/A3_Aegis/weapons_f_aegis/Rifles/SPAR_02/config.cpp
+++ b/A3_Aegis/weapons_f_aegis/Rifles/SPAR_02/config.cpp
@@ -56,17 +56,17 @@ class CfgWeapons
 				iconPosition[]={0,0.40000001};
 				iconScale=0.2;
 			};
-			class CowsSlot: CowsSlot_Rail
+			class CowsSlot: asdg_OpticRail1913
 			{
 				iconPosition[]={0.44999999,0.28};
 				iconScale=0.2;
 			};
-			class PointerSlot: PointerSlot_Rail
+			class PointerSlot: asdg_FrontSideRail
 			{
 				iconPosition[]={0.34999999,0.44999999};
 				iconScale=0.2;
 			};
-			class UnderBarrelSlot: UnderBarrelSlot_rail
+			class UnderBarrelSlot: asdg_UnderSlot
 			{
 				iconPosition[]={0.2,0.80000001};
 				iconScale=0.30000001;


### PR DESCRIPTION
The new SPAR 16 derived from the SPAR 16 S was incompatible with CBA/ASDG rail attachments.  This should fix that and allow it to work better with attachments from other mods.